### PR TITLE
Add app start telemetry probe

### DIFF
--- a/src/PortPane/App.xaml.cs
+++ b/src/PortPane/App.xaml.cs
@@ -95,7 +95,8 @@ public partial class App : Application
         ShutdownMode = ShutdownMode.OnExplicitShutdown;
 
         var settingsSvc = _serviceProvider.GetRequiredService<ISettingsService>();
-        if (!settingsSvc.Current.FirstRunComplete)
+        bool wasFirstRun = !settingsSvc.Current.FirstRunComplete;
+        if (wasFirstRun)
         {
             _serviceProvider.GetRequiredService<FirstRunDialog>().ShowDialog();
         }
@@ -104,6 +105,18 @@ public partial class App : Application
         MainWindow = _serviceProvider.GetRequiredService<MainWindow>();
         MainWindow.Show();
         ShutdownMode = ShutdownMode.OnMainWindowClose;
+
+        // ── Background: telemetry — app launch ───────────────────────────────
+        _ = Task.Run(async () =>
+        {
+            var telemetry = _serviceProvider.GetRequiredService<ITelemetryService>();
+            await telemetry.ReportEventAsync("app_start", new Dictionary<string, object>
+            {
+                ["channel"]      = ChannelInfo.Channel.ToString(),
+                ["is_portable"]  = settingsSvc.IsPortableMode,
+                ["is_first_run"] = wasFirstRun
+            });
+        });
 
         // ── Background: update check ──────────────────────────────────────────
         _ = Task.Run(async () =>


### PR DESCRIPTION
## Summary

Adds a minimal telemetry probe for successful app starts so Alpha builds can verify the Cloudflare/D1 telemetry path.

## Changes

- Reports `app_start` after the main window is shown
- Includes release channel, portable mode, and whether this was the first run
- Captures first-run state before the first-run dialog mutates settings

## Validation

- Source diff reviewed
- `git diff --check -- src/PortPane/App.xaml.cs` passed before commit

## Notes

This does not yet add install IDs, device snapshots, feature usage counters, or first-run checkbox default fixes.