### PR TITLE
Polish Settings UI controls and bump to 0.5.7

### DIFF
--- a/installer/PortPane.iss
+++ b/installer/PortPane.iss
@@ -7,7 +7,7 @@
 ; See BrandingInfo.cs for all values sourced here.
 
 #define AppName        "PortPane"
-#define AppVersion     "0.5.6"
+#define AppVersion     "0.5.7"
 #define AppPublisher   "My Computer Guru LLC"
 #define AppURL         "https://shackdesk.com"
 #define AppExeName     "PortPane.exe"

--- a/src/PortPane/BrandingInfo.cs
+++ b/src/PortPane/BrandingInfo.cs
@@ -9,7 +9,7 @@ public static class BrandingInfo
     public const string AppName           = "PortPane";
     public const string SuiteName         = "ShackDesk";
     public const string FullName          = "PortPane by ShackDesk";
-    public const string Version           = "0.5.6";
+    public const string Version           = "0.5.7";
 
     /// <summary>
     /// ISO 8601 UTC build timestamp. Empty string in source — patched by CI at

--- a/src/PortPane/PortPane.csproj
+++ b/src/PortPane/PortPane.csproj
@@ -26,9 +26,9 @@
     <Authors>Mark McDow (N4TEK)</Authors>
     <Copyright>Copyright © 2024-2026 Mark McDow. All rights reserved.</Copyright>
     <Trademark>PortPane is a trademark of My Computer Guru LLC</Trademark>
-    <Version>0.5.6</Version>
-    <FileVersion>0.5.6.0</FileVersion>
-    <AssemblyVersion>0.5.6.0</AssemblyVersion>
+    <Version>0.5.7</Version>
+    <FileVersion>0.5.7.0</FileVersion>
+    <AssemblyVersion>0.5.7.0</AssemblyVersion>
     <Description>Takes the pain out of ports — amateur radio USB device helper</Description>
     <RepositoryUrl>https://github.com/Computer-Tsu/shackdesk-portpane</RepositoryUrl>
 

--- a/src/PortPane/ViewModels/ComPortPanelViewModel.cs
+++ b/src/PortPane/ViewModels/ComPortPanelViewModel.cs
@@ -46,7 +46,8 @@ public sealed class ComPortPanelViewModel : ViewModelBase
     }
 
     public bool IsPuttyAvailable      => _putty.IsPuttyAvailable;
-    public bool CanLaunchPutty        => IsPuttyAvailable && SelectedPort is not null && !SelectedPort.IsGhost;
+    public bool ShowPuttyControls     => _settings.Current.ShowPuttyButton && IsPuttyAvailable;
+    public bool CanLaunchPutty        => ShowPuttyControls && SelectedPort is not null && !SelectedPort.IsGhost;
 
     public string CopyConfirmation
     {
@@ -89,6 +90,13 @@ public sealed class ComPortPanelViewModel : ViewModelBase
             Ports.Add(new ComPortRowViewModel(port));
         Log.Debug("COM port panel refreshed: {Count} ports ({Ghosts} ghost)",
             Ports.Count, Ports.Count(p => p.IsGhost));
+    }
+
+    public void RefreshPuttySettings()
+    {
+        OnPropertyChanged(nameof(ShowPuttyControls));
+        OnPropertyChanged(nameof(CanLaunchPutty));
+        OpenInPuttyCommand.RaiseCanExecuteChanged();
     }
 
     private async void CopyPortName(string? portName)

--- a/src/PortPane/ViewModels/SettingsViewModel.cs
+++ b/src/PortPane/ViewModels/SettingsViewModel.cs
@@ -902,6 +902,7 @@ public sealed class SettingsViewModel : ViewModelBase
         // Write LaunchAtStartup to registry
         WriteLaunchAtStartupToRegistry(_pendingLaunchAtStartup);
 
+        _mainVm.ComPorts.RefreshPuttySettings();
         _settings.Save();
     }
 

--- a/src/PortPane/Views/MainWindow.xaml
+++ b/src/PortPane/Views/MainWindow.xaml
@@ -117,8 +117,6 @@
                         <MenuItem Header="_File">
                             <MenuItem Header="Open _Settings" InputGestureText="Ctrl+,"
                                       Click="OpenSettings_Click"/>
-                            <MenuItem Header="_Save Settings" InputGestureText="Ctrl+S"
-                                      Click="SaveSettings_Click"/>
                             <Separator/>
                             <MenuItem Header="E_xit" InputGestureText="Alt+F4"
                                       Click="Exit_Click"/>
@@ -345,15 +343,14 @@
                                     Content="Open in PuTTY"
                                     Style="{StaticResource PuttyButtonStyle}"
                                     Command="{Binding ComPorts.OpenInPuttyCommand}"
-                                    Visibility="{Binding ComPorts.IsPuttyAvailable, Converter={StaticResource BoolToVis}}"
+                                    Visibility="{Binding ComPorts.ShowPuttyControls, Converter={StaticResource BoolToVis}}"
                                     Margin="6,0,0,0"/>
                             <ComboBox ItemsSource="{Binding ComPorts.BaudRates}"
                                       SelectedItem="{Binding ComPorts.SelectedBaudRate}"
                                       MinHeight="44"
                                       MinWidth="110"
                                       ToolTip="Baud rate for PuTTY launch and heuristic suggestions"
-                                      Background="{StaticResource SurfaceBrush}"
-                                      Foreground="{StaticResource TextPrimaryBrush}"/>
+                                      Visibility="{Binding ComPorts.ShowPuttyControls, Converter={StaticResource BoolToVis}}"/>
                         </DockPanel>
 
                         <!-- Copy confirmation (non-modal) -->

--- a/src/PortPane/Views/MainWindow.xaml.cs
+++ b/src/PortPane/Views/MainWindow.xaml.cs
@@ -98,9 +98,6 @@ public partial class MainWindow : Window
         win?.ShowDialog();
     }
 
-    private void SaveSettings_Click(object sender, RoutedEventArgs e)
-        => _settings.Save();
-
     private void Exit_Click(object sender, RoutedEventArgs e)
         => Application.Current.Shutdown();
 
@@ -183,7 +180,6 @@ public partial class MainWindow : Window
             switch (e.Key)
             {
                 case Key.OemComma: OpenSettings_Click(sender, e); e.Handled = true; break;
-                case Key.S:        SaveSettings_Click(sender, e); e.Handled = true; break;
                 case Key.T:        _vm.IsAlwaysOnTop = !_vm.IsAlwaysOnTop; e.Handled = true; break;
                 case Key.P:        _vm.IsComPanelVisible = !_vm.IsComPanelVisible; e.Handled = true; break;
             }

--- a/src/PortPane/Views/Themes/Default.xaml
+++ b/src/PortPane/Views/Themes/Default.xaml
@@ -81,7 +81,7 @@
     ══════════════════════════════════════════════════════════════════ -->
 
     <Style x:Key="DragStripStyle" TargetType="Border">
-        <Setter Property="Height"           Value="8"/>
+        <Setter Property="Height"           Value="16"/>
         <Setter Property="Background"       Value="{StaticResource DragStripBrush}"/>
         <Setter Property="Cursor"           Value="SizeAll"/>
         <Setter Property="ToolTip"          Value="Drag to move window"/>
@@ -272,6 +272,109 @@
         <Setter Property="Padding"          Value="6,4"/>
         <Setter Property="FontFamily"       Value="Segoe UI"/>
         <Setter Property="FontSize"         Value="13"/>
+        <Setter Property="SnapsToDevicePixels" Value="True"/>
+        <Setter Property="ItemContainerStyle">
+            <Setter.Value>
+                <Style TargetType="ComboBoxItem">
+                    <Setter Property="Background"       Value="{StaticResource SurfaceBrush}"/>
+                    <Setter Property="Foreground"       Value="{StaticResource TextPrimaryBrush}"/>
+                    <Setter Property="Padding"          Value="8,5"/>
+                    <Setter Property="FontFamily"       Value="Segoe UI"/>
+                    <Setter Property="FontSize"         Value="13"/>
+                    <Style.Triggers>
+                        <Trigger Property="IsHighlighted" Value="True">
+                            <Setter Property="Background" Value="{StaticResource AccentBrush}"/>
+                            <Setter Property="Foreground" Value="White"/>
+                        </Trigger>
+                        <Trigger Property="IsSelected" Value="True">
+                            <Setter Property="Background" Value="{StaticResource SurfaceElevatedBrush}"/>
+                            <Setter Property="Foreground" Value="{StaticResource TextPrimaryBrush}"/>
+                        </Trigger>
+                    </Style.Triggers>
+                </Style>
+            </Setter.Value>
+        </Setter>
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="ComboBox">
+                    <Grid>
+                        <ToggleButton x:Name="DropDownToggle"
+                                      Focusable="False"
+                                      ClickMode="Press"
+                                      IsChecked="{Binding IsDropDownOpen, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}">
+                            <ToggleButton.Template>
+                                <ControlTemplate TargetType="ToggleButton">
+                                    <Border x:Name="ComboChrome"
+                                            Background="{StaticResource SurfaceBrush}"
+                                            BorderBrush="{StaticResource BorderBrush}"
+                                            BorderThickness="1"
+                                            CornerRadius="3">
+                                        <Path x:Name="Arrow"
+                                              Data="M 0 0 L 4 4 L 8 0 Z"
+                                              Fill="{StaticResource TextPrimaryBrush}"
+                                              HorizontalAlignment="Right"
+                                              VerticalAlignment="Center"
+                                              Margin="0,0,9,0"/>
+                                    </Border>
+                                    <ControlTemplate.Triggers>
+                                        <Trigger Property="IsMouseOver" Value="True">
+                                            <Setter TargetName="ComboChrome" Property="Background" Value="{StaticResource SurfaceElevatedBrush}"/>
+                                        </Trigger>
+                                        <Trigger Property="IsEnabled" Value="False">
+                                            <Setter TargetName="ComboChrome" Property="Opacity" Value="0.5"/>
+                                        </Trigger>
+                                    </ControlTemplate.Triggers>
+                                </ControlTemplate>
+                            </ToggleButton.Template>
+                        </ToggleButton>
+
+                        <TextBlock x:Name="ContentSite"
+                                   Margin="8,0,28,0"
+                                   HorizontalAlignment="Left"
+                                   VerticalAlignment="Center"
+                                   Foreground="{StaticResource TextPrimaryBrush}"
+                                   IsHitTestVisible="False"
+                                   TextTrimming="CharacterEllipsis">
+                            <TextBlock.Text>
+                                <PriorityBinding>
+                                    <Binding RelativeSource="{RelativeSource TemplatedParent}"
+                                             Path="SelectedItem.DisplayName"/>
+                                    <Binding RelativeSource="{RelativeSource TemplatedParent}"
+                                             Path="SelectionBoxItem"/>
+                                </PriorityBinding>
+                            </TextBlock.Text>
+                        </TextBlock>
+
+                        <Popup x:Name="PART_Popup"
+                               Placement="Bottom"
+                               IsOpen="{TemplateBinding IsDropDownOpen}"
+                               AllowsTransparency="True"
+                               Focusable="False"
+                               PopupAnimation="Slide">
+                            <Grid MinWidth="{Binding ActualWidth, RelativeSource={RelativeSource TemplatedParent}}"
+                                  MaxHeight="{TemplateBinding MaxDropDownHeight}">
+                                <Border Background="{StaticResource SurfaceBrush}"
+                                        BorderBrush="{StaticResource BorderBrush}"
+                                        BorderThickness="1"
+                                        CornerRadius="3">
+                                    <ScrollViewer Margin="0"
+                                                  SnapsToDevicePixels="True"
+                                                  CanContentScroll="True">
+                                        <ItemsPresenter/>
+                                    </ScrollViewer>
+                                </Border>
+                            </Grid>
+                        </Popup>
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="IsEnabled" Value="False">
+                            <Setter Property="Foreground" Value="{StaticResource TextSecondaryBrush}"/>
+                            <Setter TargetName="ContentSite" Property="Opacity" Value="0.5"/>
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
     </Style>
 
     <Style TargetType="ComboBoxItem">


### PR DESCRIPTION
## Summary

This PR handles the small Settings/UI polish pass we reviewed before moving on to backend reporting helpers.

- Removes the confusing main window `File > Save Settings` command and its `Ctrl+S` shortcut, since Settings OK already saves settings.
- Improves the shared dark ComboBox styling so Settings dropdowns and main-window selectors use readable foreground/background colors.
- Hides the COM baud selector with the PuTTY launch controls unless the saved `ShowPuttyButton` setting is enabled and PuTTY is available.
- Refreshes the PuTTY control visibility after Settings OK so that toggle does not require an app restart.
- Increases the always-visible drag strip height from 8px to 16px to make the window easier to grab and move.
- Bumps PortPane app/installer metadata from `0.5.6` to `0.5.7`.

## Validation

- Ran `git diff --check` successfully.
- Could not run a local .NET build in this WSL workspace because `dotnet` is not installed here.

## Human test checklist

- Open main window menu and confirm `File > Save Settings` is gone.
- Confirm `Ctrl+,` still opens Settings and `Ctrl+S` no longer does a hidden save.
- Open Settings dropdowns in dark mode and confirm selected/open list text is readable.
- Toggle `Show PuTTY button` in Settings, click OK, and confirm the main window PuTTY button and baud selector appear/disappear together.
- Confirm the top drag strip is easier to grab without feeling too chunky.
- Confirm About/build metadata reports `0.5.7-alpha...` for branch builds.