### PR TITLE
Fix Settings audio test and donate link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Telemetry startup reporting for alpha builds, including app version, channel, portable mode,
+  first-run state, and a per-install Support ID for support lookups.
+- USB radio-interface telemetry snapshots for known/unknown COM and audio endpoint detection,
+  limited to VID/PID and database match status rather than raw device names or serial numbers.
+- Settings/About display for the telemetry Support ID, formatted with UUID dashes for readability.
+- Inno Setup alpha installer test artifacts for early installer and update testing.
 - `ChannelInfo.cs`: multi-channel release system — `ReleaseChannel` enum (`Alpha`, `Beta`, `Stable`)
   with per-branch constants controlling build expiry, feature unlock, telemetry default,
   logging verbosity, and version suffix; protected from forward merges via `.gitattributes` `merge=ours`
@@ -63,6 +69,14 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- Settings ComboBox styling now uses a shared dark template for both expanded dropdown items
+  and collapsed selections, fixing low-contrast text and object-record display text.
+- Settings License tab Donate button now opens `https://shackdesk.com/donate`.
+- Settings Audio tab PC test button now treats `(none)` as the current Windows default
+  playback endpoint instead of silently doing nothing.
+- Main window `File > Save Settings` command and hidden `Ctrl+S` save shortcut removed;
+  Settings OK remains the settings save action.
+- Main window drag strip made easier to grab with the mouse.
 - Chrome menu bar auto-hides after 5 seconds making the menu unusable; replaced
   5-second `DispatcherTimer` with focus/hover model: chrome appears on mouse-enter,
   pins on click or Alt key (enabling keyboard menu navigation), and hides only when
@@ -70,8 +84,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Project version bumped to `0.5.7` in branding, assembly/package metadata, and the
+  Inno Setup installer definition.
+- COM baud selector now appears with the PuTTY launch controls only when the PuTTY
+  button setting is enabled and PuTTY is available.
 - License baseline switched from GPL v3 to MIT across app metadata, installer packaging, and user-facing strings
-- Project version bumped to `0.5.6` in branding and assembly/package metadata
 
 - `BrandingInfo.Version` stripped of channel suffix (was `"0.5.1-beta"`); suffix now provided
   exclusively by `ChannelInfo.VersionSuffix` on each branch

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Device Manager.
 
 [![dev](https://github.com/Computer-Tsu/shackdesk-portpane/actions/workflows/build.yml/badge.svg?branch=dev)](https://github.com/Computer-Tsu/shackdesk-portpane/actions/workflows/build.yml)
 [![main](https://github.com/Computer-Tsu/shackdesk-portpane/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/Computer-Tsu/shackdesk-portpane/actions/workflows/build.yml)
-[![Alpha](https://img.shields.io/badge/alpha-0.5.6-orange)](https://github.com/Computer-Tsu/shackdesk-portpane/releases)
+[![Alpha](https://img.shields.io/badge/alpha-0.5.7-orange)](https://github.com/Computer-Tsu/shackdesk-portpane/releases)
 [![Stable](https://img.shields.io/github/v/release/Computer-Tsu/shackdesk-portpane?label=stable&color=brightgreen)](https://github.com/Computer-Tsu/shackdesk-portpane/releases/latest)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE-MIT.md)
 [![Last Commit](https://img.shields.io/github/last-commit/Computer-Tsu/shackdesk-portpane)](https://github.com/Computer-Tsu/shackdesk-portpane/commits/main)
@@ -34,7 +34,9 @@ Device Manager.
 | **Alpha** | [Latest Alpha release](https://github.com/Computer-Tsu/shackdesk-portpane/releases/tag/latest-alpha) | Updated on every `dev` push. 14-day expiry. For testers. |
 | **Stable** | [Latest stable release](https://github.com/Computer-Tsu/shackdesk-portpane/releases/latest) | No stable release yet — coming soon. |
 
-Download `PortPane.exe`. Run it directly. No installation required.
+Alpha builds may include a portable `PortPane.exe`, a `.zip`, and an installer test build.
+The portable exe can run directly without installation; the installer is available for
+early update/install testing.
 
 > **Windows SmartScreen note:** PortPane is currently unsigned (code signing certificate pending).
 > If SmartScreen blocks it, click "More info" → "Run anyway." This is expected for unsigned utilities.
@@ -67,6 +69,7 @@ Clarity and simplicity take precedence over feature density.
 - Instantly shows COM port name and friendly device name when USB device connects
 - Lists audio playback and capture devices, grouped as USB/External vs Built-in
 - **One-click audio profile switching** — toggle between PC audio and radio CODEC with one button
+- Settings audio test buttons for checking the selected PC/radio playback endpoints
 - Identifies known radio interfaces by VID/PID (SignaLink, DigiRig, RIGblaster, IC-7300, etc.)
 - Radio interfaces are badged and highlighted
 - USB hotplug detection — updates the device list within 2 seconds of plug/unplug
@@ -80,7 +83,7 @@ Clarity and simplicity take precedence over feature density.
 - Persistent window position and settings
 - Portable mode — run from USB drive with settings stored alongside the exe
 - Auto-update via Velopack (background, non-interrupting)
-- Optional anonymous telemetry (disabled by default)
+- Optional anonymous telemetry with local Support ID and USB radio-interface hit/miss reporting
 - MIT licensed — full source available
 
 ---
@@ -189,9 +192,8 @@ RIGblaster, and other referenced product names.
 
 ## Support the Author
 
-<!-- GitHub Sponsors / Ko-fi links — to be added when accounts are created -->
-
-If PortPane saves you time, consider leaving a star on GitHub.
+If PortPane saves you time, consider leaving a star on GitHub or visiting
+[shackdesk.com/donate](https://shackdesk.com/donate).
 
 ---
 

--- a/src/PortPane/BrandingInfo.cs
+++ b/src/PortPane/BrandingInfo.cs
@@ -63,7 +63,7 @@ public static class BrandingInfo
     public const string RepoURL           = "https://github.com/Computer-Tsu/shackdesk-portpane";
     public const string AppURL            = "https://shackdesk.com";
     public const string SupportURL        = "https://github.com/Computer-Tsu/shackdesk-portpane/discussions";
-    public const string DonationURL       = "";
+    public const string DonationURL       = "https://shackdesk.com/donate";
     public const string LicenseType       = "MIT / Commercial";
     public const string TelemetryEndpoint = "https://telemetry.shackdesk.com/report";
 

--- a/src/PortPane/ViewModels/SettingsViewModel.cs
+++ b/src/PortPane/ViewModels/SettingsViewModel.cs
@@ -560,14 +560,23 @@ public sealed class SettingsViewModel : ViewModelBase
             try
             {
                 using var enumerator = new MMDeviceEnumerator();
-                // Find device by matching friendly name since we store FriendlyName
-                var allDevices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
-                foreach (var d in allDevices)
+                if (string.IsNullOrWhiteSpace(storageName))
                 {
-                    if (d.FriendlyName == storageName)
+                    if (!isPc) return;
+                    device = enumerator.GetDefaultAudioEndpoint(DataFlow.Render, Role.Multimedia);
+                }
+
+                // Find device by matching friendly name since we store FriendlyName
+                if (device is null)
+                {
+                    var allDevices = enumerator.EnumerateAudioEndPoints(DataFlow.Render, DeviceState.Active);
+                    foreach (var d in allDevices)
                     {
-                        device = d;
-                        break;
+                        if (d.FriendlyName == storageName)
+                        {
+                            device = d;
+                            break;
+                        }
                     }
                 }
             }

--- a/src/PortPane/Views/AboutDialog.xaml
+++ b/src/PortPane/Views/AboutDialog.xaml
@@ -44,7 +44,7 @@
                    HorizontalAlignment="Center"
                    Margin="0,2,0,16">
             <Run Text="Version "/>
-            <Run Text="{x:Static local:BrandingInfo.Version}"/>
+            <Run Text="{x:Static local:BrandingInfo.FullVersion}"/>
         </TextBlock>
 
         <!-- Author -->


### PR DESCRIPTION
## Summary

This follows up on the Settings window issues found after the UI polish pass.

- Sets `BrandingInfo.DonationURL` to `https://shackdesk.com/donate` so the License tab Donate button has a real destination.
- Makes the PC audio test treat the `(none)` playback selection as the current Windows default playback endpoint.
- Leaves Radio audio monitor/test behavior unchanged for now because routing radio input to PC speakers is a separate feature design.

## Why

The Donate button was wired to `BrandingInfo.DonationURL`, but that URL was blank, so clicking it did nothing.

The PC audio test could also appear to do nothing when PC Playback was set to `(none)`. That item is stored with an empty `StorageName`, and the old code tried to find an active render device whose friendly name was empty, then returned silently. Using the Windows default playback endpoint better matches what `(none)` means in the Settings UI.

## Validation

- Ran `git diff --check` successfully.
- Could not run a local .NET build because `dotnet` is not installed in this WSL workspace.

## Manual Test Checklist

- In Settings > License, click Donate and confirm it opens `https://shackdesk.com/donate`.
- In Settings > Audio, leave PC Playback set to `(none)` and confirm Test PC audio plays through the current Windows default output.
- Select a specific PC Playback device and confirm Test PC audio still plays through that device.
- Confirm the Radio test button behavior is unchanged for this PR.