### PR TITLE
Installer fixes and improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -277,6 +277,14 @@ jobs:
           dotnet restore ${{ env.SOLUTION }}
           dotnet publish ${{ env.APP_PROJECT }} --configuration Release --runtime ${{ env.RID }} --self-contained true -p:PublishSingleFile=true --output ./publish
 
+      - name: Compute SHA-256 for installer payload
+        shell: pwsh
+        run: |
+          # Future optimization: download and reuse the publish artifact/hash instead of recomputing here.
+          $hash = (Get-FileHash -Algorithm SHA256 './publish/${{ env.APP_EXE }}').Hash.ToLower()
+          $hash | Out-File -FilePath './publish/${{ env.APP_EXE }}.sha256' -NoNewline
+          echo "SHA256: $hash"
+
       - name: Build Inno Setup installer
         shell: pwsh
         run: |

--- a/docs/INSTALLER_NOTE.txt
+++ b/docs/INSTALLER_NOTE.txt
@@ -1,0 +1,6 @@
+PortPane Installer Notes
+
+- This installer deploys the Windows x64 build of PortPane.
+- Administrative rights are not required for the default install path selection used by this build.
+- If you are testing a pre-release build, newer builds may replace this one during future updates.
+

--- a/installer/PortPane.iss
+++ b/installer/PortPane.iss
@@ -70,7 +70,7 @@ Source: "..\OFFICIAL_BUILDS_AND_SERVICES.md"; DestDir: "{app}"; Flags: ignorever
 [Icons]
 Name: "{group}\{#AppName}";            Filename: "{app}\{#AppExeName}"; Comment: "{#AppDescription}"
 Name: "{group}\Uninstall {#AppName}";  Filename: "{uninstallexe}"
-Name: "{commondesktop}\{#AppName}";    Filename: "{app}\{#AppExeName}"; Comment: "{#AppDescription}"; Tasks: desktopicon
+Name: "{autodesktop}\{#AppName}";      Filename: "{app}\{#AppExeName}"; Comment: "{#AppDescription}"; Tasks: desktopicon
 Name: "{userstartmenu}\{#AppName}";    Filename: "{app}\{#AppExeName}"; Comment: "{#AppDescription}"; Tasks: startmenuicon
 
 [Run]

--- a/installer/PortPane.iss
+++ b/installer/PortPane.iss
@@ -91,11 +91,12 @@ begin
   begin
     ExePath  := ExpandConstant('{app}\{#AppExeName}');
     HashPath := ExpandConstant('{app}\{#AppExeName}.sha256');
-    if FileExists(HashPath) then
-    begin
-      LoadStringFromFile(HashPath, StoredHash);
-      // Note: Full SHA-256 verification requires a PowerShell call or custom DLL.
-      // Placeholder — the build pipeline verifies the hash before packaging.
-    end;
+    // Placeholder only. Full SHA-256 verification would require a PowerShell call
+    // or custom DLL. The build pipeline already verifies and packages the hash.
+    // Temporarily disabled while stabilizing CI installer creation.
+    // if FileExists(HashPath) then
+    // begin
+    //   LoadStringFromFile(HashPath, StoredHash);
+    // end;
   end;
 end;

--- a/installer/PortPane.iss
+++ b/installer/PortPane.iss
@@ -40,7 +40,8 @@ DisableProgramGroupPage=yes
 PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
 ArchitecturesInstallIn64BitMode=x64compatible
-MinVersion=10.0.17763   ; Windows 10 1809
+; Windows 10 1809 minimum
+MinVersion=10.0.17763
 
 ; Code signing placeholder
 ; SignTool=standard sign /fd sha256 /tr http://timestamp.digicert.com /td sha256 $f


### PR DESCRIPTION
## Summary

- Normalize MinVersion comment in installer script
- Add missing installer note file shown before installation
- Generate SHA-256 hash in installer CI job
- Disable unfinished placeholder hash verification in installer script
- Fix desktop shortcut targeting Public\Desktop when running as current user

## Commits

- `afc9845` installer: normalize MinVersion for Inno test
- `36f2351` installer: add missing installer note file
- `342f523` installer: generate hash in installer job
- `64b7e22` installer: disable placeholder hash read in script
- `13180fa` installer: use autodesktop for per-user and all-users desktop shortcut

## Bug fix detail

`{commondesktop}` always resolves to `C:\Users\Public\Desktop`, which requires
admin rights. When the installer runs as current user (no admin), creating the
desktop shortcut fails. Changed to `{autodesktop}`, which resolves to the current
user's desktop for per-user installs and Public\Desktop for all-users (admin)
installs — consistent with `{autopf}` already used for the install directory.

## Test plan

- [ ] Run installer as current user (no admin) with desktop shortcut selected — shortcut should appear on current user's desktop
- [ ] Run installer as admin (all users) with desktop shortcut selected — shortcut should appear on Public\Desktop
- [ ] Confirm installer note file displays before installation begins
- [ ] Confirm SHA-256 hash is present in installer CI artifacts