### PR TITLE
Scaffold SignPath OSS code signing job (disabled pending approval)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -223,17 +223,24 @@ jobs:
           # Obfuscation will be added before v1.0 stable release.
           Write-Host "Obfuscation step placeholder — skipping"
 
-      # Code signing placeholder:
-      # When an EV or OV certificate is obtained, add the following step here:
-      #   - name: Sign executable
-      #     run: >
-      #       signtool.exe sign
-      #         /fd sha256
-      #         /tr http://timestamp.digicert.com
-      #         /td sha256
-      #         /f certificate.pfx
-      #         /p ${{ secrets.SIGNING_PASSWORD }}
-      #         ./publish/${{ env.APP_EXE }}
+      # ── SignPath code signing ────────────────────────────────────────────
+      # PortPane uses SignPath (https://signpath.io) for code signing under the
+      # SignPath OSS program. Signing is submitted via the
+      # signpath/github-action-submit-signing-request action after publish.
+      #
+      # STATUS: Pending SignPath OSS program approval.
+      #         The signing job below is scaffolded but DISABLED until approval
+      #         is received and the required values are filled in.
+      #
+      # WHEN APPROVED — fill in and enable the signing job further below:
+      #   SIGNPATH_ORG_ID      — from SignPath dashboard → Organization settings
+      #   SIGNPATH_PROJECT     — SignPath project slug for PortPane
+      #   SIGNPATH_POLICY      — signing policy slug (e.g. "release-signing")
+      #   SIGNPATH_ARTIFACT    — artifact configuration slug
+      #   SIGNPATH_API_TOKEN   — add as a GitHub Actions secret in repo settings
+      #
+      # See: https://github.com/SignPath/github-action-submit-signing-request
+      # See: CODE_SIGNING_POLICY.md for the full SignPath rollout plan.
 
       - name: Compute SHA-256
         id: hash
@@ -479,3 +486,46 @@ jobs:
             -Body $body `
             -ContentType 'application/json'
           echo "Dispatched alpha update for v$version"
+
+  # ─────────────────────────────────────────────────────────────────────
+  # SignPath code signing
+  # ─────────────────────────────────────────────────────────────────────
+  # STATUS: DISABLED — pending SignPath OSS program approval.
+  #
+  # This job is scaffolded with the correct structure required by SignPath
+  # so the workflow is compliant when the cert is issued.
+  #
+  # TO ENABLE when SignPath OSS approval is received:
+  #   1. Replace all TODO placeholders below with real values from
+  #      the SignPath dashboard.
+  #   2. Add SIGNPATH_API_TOKEN as a secret in GitHub repo settings
+  #      (Settings → Secrets and variables → Actions → New repository secret).
+  #   3. Change the `if: false` condition to the appropriate trigger
+  #      (e.g. startsWith(github.ref, 'refs/tags/v')).
+  #   4. Test on alpha first (see CODE_SIGNING_POLICY.md).
+  #
+  # SignPath OSS program: https://signpath.io/product/open-source
+  # Action docs: https://github.com/SignPath/github-action-submit-signing-request
+  # ─────────────────────────────────────────────────────────────────────
+  sign:
+    name: Sign with SignPath
+    runs-on: ubuntu-latest
+    needs: publish
+    if: false  # TODO: change to trigger condition when SignPath OSS is approved
+
+    permissions:
+      id-token: write    # required by SignPath action for OIDC authentication
+
+    steps:
+      - name: Submit signing request to SignPath
+        uses: signpath/github-action-submit-signing-request@v1
+        with:
+          # TODO: fill in from SignPath dashboard after OSS approval
+          api-token:                   ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id:             'TODO-signpath-org-id'
+          project-slug:                'TODO-portpane'
+          signing-policy-slug:         'TODO-release-signing'
+          artifact-configuration-slug: 'TODO-initial'
+          github-artifact-id:          ${{ needs.publish.outputs.sha256 }}
+          wait-for-completion:         true
+          output-artifact-directory:   './signed'


### PR DESCRIPTION
## Summary

- Replaces the `signtool.exe` comment placeholder with the correct SignPath workflow structure
- Adds a `sign` job using `signpath/github-action-submit-signing-request@v1`
- Job is gated with `if: false` — will **not** execute until SignPath OSS approval is received
- All TODO values are clearly marked for when approval arrives
- SignPath is named explicitly throughout so code search finds this file

## To enable when approved

1. Replace `TODO` placeholder values with real values from the SignPath dashboard
2. Add `SIGNPATH_API_TOKEN` as a GitHub Actions secret
3. Change `if: false` to the appropriate trigger (e.g. `startsWith(github.ref, 'refs/tags/v')`)
4. Test on alpha first per `CODE_SIGNING_POLICY.md`

## Test plan

- [ ] Confirm CI build runs clean on `dev` after merge (signing job should be skipped due to `if: false`)
- [ ] Confirm no new workflow errors introduced