### PR TITLE
docs: update README with Velopack installer download and download guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,26 @@ Device Manager.
 
 | Channel | Link | Notes |
 | --- | --- | --- |
-| **Alpha** | [Latest Alpha release](https://github.com/Computer-Tsu/shackdesk-portpane/releases/tag/latest-alpha) | Updated on every `dev` push. 14-day expiry. For testers. |
+| **Alpha** | [Direct installer download](https://github.com/Computer-Tsu/ShackDesk-PortPane/releases/download/latest-alpha/PortPane-win-Setup.exe) | Updated on every `dev` push. 14-day expiry. For testers. |
+| **Alpha (release page)** | [Latest Alpha release](https://github.com/Computer-Tsu/shackdesk-portpane/releases/tag/latest-alpha) | Includes SHA-256 hash and portable exe. |
 | **Stable** | [Latest stable release](https://github.com/Computer-Tsu/shackdesk-portpane/releases/latest) | No stable release yet — coming soon. |
 
-Download `PortPane.exe`. Run it directly. No installation required.
+**Alpha installer** (`PortPane-win-Setup.exe`) installs per-user with no admin rights required.
+In-app updates are delivered automatically — no need to reinstall for new alpha builds.
 
-> **Windows SmartScreen note:** PortPane is currently unsigned (code signing certificate pending).
-> If SmartScreen blocks it, click "More info" → "Run anyway." This is expected for unsigned utilities.
-> Verify the SHA-256 hash posted with each release.
+> **Windows SmartScreen / browser warning:** PortPane is currently unsigned (code signing
+> certificate pending). Browsers and Windows will show a warning before the file can run.
+> See the **[download guide](https://shackdesk.com/portpane/download/)** for step-by-step
+> instructions for Chrome, Edge, Windows 10, and Windows 11.
 
 ---
 
 ## Quick Start
 
-1. Download `PortPane.exe` from Releases
-2. Run it (no install, no admin rights needed)
-3. Plug in your USB radio interface — PortPane updates instantly
+1. Download `PortPane-win-Setup.exe` from the [alpha release](https://github.com/Computer-Tsu/ShackDesk-PortPane/releases/download/latest-alpha/PortPane-win-Setup.exe)
+2. Run the installer — no admin rights needed, installs per-user
+3. If Windows or your browser warns you, see the [download guide](https://shackdesk.com/portpane/download/)
+4. Plug in your USB radio interface — PortPane updates instantly
 
 ---
 
@@ -67,6 +71,7 @@ Clarity and simplicity take precedence over feature density.
 - Instantly shows COM port name and friendly device name when USB device connects
 - Lists audio playback and capture devices, grouped as USB/External vs Built-in
 - **One-click audio profile switching** — toggle between PC audio and radio CODEC with one button
+- Settings audio test buttons for checking the selected PC/radio playback endpoints
 - Identifies known radio interfaces by VID/PID (SignaLink, DigiRig, RIGblaster, IC-7300, etc.)
 - Radio interfaces are badged and highlighted
 - USB hotplug detection — updates the device list within 2 seconds of plug/unplug
@@ -80,7 +85,7 @@ Clarity and simplicity take precedence over feature density.
 - Persistent window position and settings
 - Portable mode — run from USB drive with settings stored alongside the exe
 - Auto-update via Velopack (background, non-interrupting)
-- Optional anonymous telemetry (disabled by default)
+- Optional anonymous telemetry with local Support ID and USB radio-interface hit/miss reporting
 - MIT licensed — full source available
 
 ---
@@ -189,9 +194,8 @@ RIGblaster, and other referenced product names.
 
 ## Support the Author
 
-<!-- GitHub Sponsors / Ko-fi links — to be added when accounts are created -->
-
-If PortPane saves you time, consider leaving a star on GitHub.
+If PortPane saves you time, consider leaving a star on GitHub or visiting
+[shackdesk.com/donate](https://shackdesk.com/donate).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds direct alpha installer download link (`PortPane-win-Setup.exe`) to the download table alongside the release page link
- Explains per-user install / auto-update via Velopack in the download section
- Updates SmartScreen note to reference the new download guide at shackdesk.com/portpane/download/
- Updates Quick Start to reflect installer flow (4 steps)
- Adds *Settings audio test buttons* and expanded telemetry description to Features list
- Replaces Sponsors placeholder comment with donation link

## Why direct-to-main

Documentation-only change; identical content already lives on `dev` branch. No code is touched.

## Test plan

- [ ] Verify installer direct-download link resolves to `latest-alpha` release asset
- [ ] Verify download guide URL goes to the new help page (after ShackDesk-Site PR is merged)
- [ ] Confirm badges and screenshot render correctly on GitHub