### PR TITLE
feat: per-channel default update check frequency (alpha=daily, beta/stable=weekly)

### DIFF
--- a/src/PortPane/ChannelInfo.cs
+++ b/src/PortPane/ChannelInfo.cs
@@ -49,4 +49,14 @@ public static class ChannelInfo
     /// Beta: "beta". Stable: empty string.
     /// </summary>
     public const string VersionSuffix = "alpha";
+
+    /// <summary>
+    /// Default update check frequency for new installs on this channel.
+    /// Matches the strings shown in Settings → Updates → Check Frequency.
+    /// Alpha: "Daily"  — builds ship on every dev push.
+    /// Beta:  "Weekly" — builds ship less often.
+    /// Stable:"Weekly" — releases are infrequent.
+    /// Manual "Check for Updates" always bypasses this interval (force = true).
+    /// </summary>
+    public const string UpdateCheckFrequencyDefault = "Daily";
 }

--- a/src/PortPane/Models/AppSettings.cs
+++ b/src/PortPane/Models/AppSettings.cs
@@ -67,7 +67,7 @@ public sealed class AppSettings
     // Updates
     public string UpdateCheckLastRun   { get; set; } = string.Empty;
     public bool   AutoUpdateEnabled    { get; set; } = true;
-    public string UpdateCheckFrequency { get; set; } = "Monthly";
+    public string UpdateCheckFrequency { get; set; } = ChannelInfo.UpdateCheckFrequencyDefault;
     public string UpdateChannel        { get; set; } = ChannelInfo.Channel.ToString();
 
     // Lifecycle

--- a/src/PortPane/ViewModels/SettingsViewModel.cs
+++ b/src/PortPane/ViewModels/SettingsViewModel.cs
@@ -113,7 +113,7 @@ public sealed class SettingsViewModel : ViewModelBase
         _pendingTelemetryEnabled     = s.TelemetryEnabled;
         _pendingTelemetryFrequency   = s.TelemetryFrequency ?? "Monthly";
         _pendingAutoUpdateEnabled    = s.AutoUpdateEnabled;
-        _pendingUpdateCheckFrequency = s.UpdateCheckFrequency ?? "Monthly";
+        _pendingUpdateCheckFrequency = s.UpdateCheckFrequency ?? ChannelInfo.UpdateCheckFrequencyDefault;
         _pendingUpdateChannel        = string.IsNullOrWhiteSpace(s.UpdateChannel)
             ? ChannelInfo.Channel.ToString()
             : s.UpdateChannel;


### PR DESCRIPTION
## Summary

Adds `UpdateCheckFrequencyDefault` to `ChannelInfo.cs` so each branch declares its own sensible default for how often background update checks run:

| Channel | Default |
|---------|---------|
| Alpha (dev) | Daily |
| Beta | Weekly |
| Stable | Weekly |

The `"Monthly"` default that was previously hardcoded in `AppSettings` and `SettingsViewModel` is replaced by the channel constant.

## Files changed

- **`ChannelInfo.cs`** (dev) — adds `UpdateCheckFrequencyDefault = "Daily"`
- **`Models/AppSettings.cs`** — `UpdateCheckFrequency` default changed from `"Monthly"` to `ChannelInfo.UpdateCheckFrequencyDefault`
- **`ViewModels/SettingsViewModel.cs`** — null-coalesce fallback changed from `"Monthly"` to `ChannelInfo.UpdateCheckFrequencyDefault`

`ChannelInfo.cs` on `beta` and `main` already have `UpdateCheckFrequencyDefault = "Weekly"` committed directly on those branches, so they are ready when this code merges forward.

## Behaviour

- **New installs**: get the channel-appropriate default immediately
- **Existing installs** with a stored frequency: their setting is respected; no migration needed
- **Force checks** (`Check for Updates` menu, `Update Now` button): always bypass the interval — no change

## Test plan

- [ ] Fresh alpha install defaults to Daily in Settings → Updates
- [ ] Manual "Check for Updates" triggers immediately regardless of last-check time
- [ ] Alpha install that already has "Monthly" stored keeps "Monthly" (user choice respected)